### PR TITLE
Release ready 2.05.001

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,7 +13,7 @@
  *
  * @since 1.0.0
  */
-define( 'GRIGORA_DEBUG', true );
+define( 'GRIGORA_DEBUG', false );
 define( 'GRIGORA_VERSION', wp_get_theme()->get( 'Version' ) );
 define( 'GRIGORA_HOME', 'https://wpgrigora.com/');
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: latracal
 Tested up to: 5.9
 Requires at least: 5.9
 Requires PHP: 7.4
-Version: 2.04.001
+Version: 2.05.001
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Copyright: latracal
@@ -32,6 +32,21 @@ Grigora Blocks is licensed under the GNU General Public License v2 or later.
 == Changelog ==
 
 All changes will be noted here
+
+== v2.05.001 ==
+Addition: New Pattern (Slanting Cover) to replicate the screenhot
+Addition: Translation-ready
+Addition: RTL Ready
+Addition: Input boxes css (scss/helpers/forms)
+Addition: E-commerce support
+Bug fix: Nested list margin bottom fix
+Bug fix: Pingback and Traceback comments margin fix
+Bug fix: Css fixes for list type of blocks
+Bug fix: Input type search -> background color Transparent
+Bug fix: Transparent header inside cover was forced to 100% width causing two lines in same row
+Improvement: Hide commentbox on post, page if its empty or comments are not allowed
+Improvement: Screenshot Tweaks
+Improvement (devs): Load unminified css if debug true
 
 == v2.04.001 ==
 Major Update: CSS is now normalized and individual CSS is added to elements. ( scss/helpers/ )

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ Text Domain: grigora-blocks
 Requires at least: 5.9
 Requires PHP: 7.4
 Tested up to: 5.9
-Version: 2.04.001
+Version: 2.05.001
 
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
== v2.05.001 ==
Addition: New Pattern (Slanting Cover) to replicate the screenhot
Addition: Translation-ready
Addition: RTL Ready
Addition: Input boxes css (scss/helpers/forms)
Addition: E-commerce support
Bug fix: Nested list margin bottom fix
Bug fix: Pingback and Traceback comments margin fix
Bug fix: Css fixes for list type of blocks
Bug fix: Input type search -> background color Transparent
Bug fix: Transparent header inside cover was forced to 100% width causing two lines in same row
Improvement: Hide commentbox on post, page if its empty or comments are not allowed
Improvement: Screenshot Tweaks
Improvement (devs): Load unminified css if debug true